### PR TITLE
Add Equal.object to ServiceTarget so equivalency can be used in Fluent Assertions.  Without this since ServiceTarget is a class the only check is if two objects are the SAME object (i.e. reference check only)

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.Tests/Internal/AppScopedHaContextProviderTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Internal/AppScopedHaContextProviderTest.cs
@@ -149,7 +149,7 @@ public sealed class AppScopedHaContextProviderTest : IDisposable
 
         executeCommand!.Sequence[0].GetType().GetProperty("service")!.GetValue(executeCommand.Sequence[0])!.Should().Be("domain.service");
         executeCommand.Sequence[0].GetType().GetProperty("data")!.GetValue(executeCommand.Sequence[0])!.Should().BeEquivalentTo(serviceData);
-        executeCommand.Sequence[0].GetType().GetProperty("target")!.GetValue(executeCommand.Sequence[0])!.Should().BeEquivalentTo(serviceTarget);
+        executeCommand.Sequence[0].GetType().GetProperty("target")!.GetValue(executeCommand.Sequence[0])!.Should().BeEquivalentTo(serviceTarget, options => options.ComparingByMembers<ServiceTarget>());
     }
 
     [Fact]

--- a/src/HassModel/NetDaemon.HassModel.Tests/ServiceTargetTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/ServiceTargetTest.cs
@@ -27,4 +27,48 @@ public class ServiceTargetTest
 
         serviceTarget.EntityIds.Should().BeEquivalentTo("light.kitchen", "light.livingroom");
     }
+
+    [Fact]
+    public void ServiceTargetAndObjectShouldBeEqual()
+    {
+        var serviceTarget1 = ServiceTarget.FromEntity("light.kitchen");
+        object serviceTarget2 = ServiceTarget.FromEntity("light.kitchen");
+        serviceTarget1.Should().Be(serviceTarget2);
+    }
+
+    [Fact]
+    public void ServiceTargetsShouldBeEqual()
+    {
+        var serviceTarget1 = ServiceTarget.FromEntity("light.kitchen");
+        var serviceTarget2 = ServiceTarget.FromEntity("light.kitchen");
+        serviceTarget1.Should().Be(serviceTarget2);
+    }
+
+    [Fact]
+    public void ServiceTargetsOperatorEqualNotOverridden()
+    {
+        var serviceTarget1 = ServiceTarget.FromEntities("light.kitchen", "light.livingroom");
+        var serviceTarget2 = ServiceTarget.FromEntities("light.kitchen", "light.livingroom");
+
+        // The == operator is not overridden, so the == operator for ServiceTarget will only work on reference equality.
+        Assert.False((serviceTarget1 == serviceTarget2), "ServiceTargets should not be equal using ==");
+    }
+
+    [Fact]
+    public void ServiceTargetsOperatorEqualReference()
+    {
+        var serviceTarget1 = ServiceTarget.FromEntities("light.kitchen", "light.livingroom");
+        var serviceTarget1b = serviceTarget1;   // Reference to the same object
+
+        Assert.True((serviceTarget1 == serviceTarget1b), "ServiceTargets references should be equal using ==");
+    }
+
+    [Fact]
+    public void ServiceTargetObjectEqualShouldBeTrue()
+    {
+        var serviceTarget1 = ServiceTarget.FromEntity("light.kitchen");
+        object serviceTarget2 = ServiceTarget.FromEntity("light.kitchen");
+
+        Assert.True(serviceTarget1.Equals(serviceTarget2), "ServiceTargets should be equal using Equals.object");
+    }
 }

--- a/src/HassModel/NetDaemon.HassModel/ServiceTarget.cs
+++ b/src/HassModel/NetDaemon.HassModel/ServiceTarget.cs
@@ -30,6 +30,77 @@ public class ServiceTarget
         new() { EntityIds = [.. entityIds] };
 
     /// <summary>
+    /// Override low level object Equals.  This is used by fluent assertions and other libraries to compare objects 
+    /// </summary>
+    /// <param name="obj">The object that we are comparing to</param>
+    /// <returns>true if the two objects are the same (Reference equal), or if the two objects are ServiceTargets and passes the Equal test</returns>
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        ServiceTarget other = (ServiceTarget)obj;
+        //return Equals((ServiceTarget)obj);
+        return AreCollectionsEqual(EntityIds, other.EntityIds)
+            && AreCollectionsEqual(DeviceIds, other.DeviceIds)
+            && AreCollectionsEqual(AreaIds, other.AreaIds)
+            && AreCollectionsEqual(FloorIds, other.FloorIds)
+            && AreCollectionsEqual(LabelIds, other.LabelIds);
+
+    }
+
+    private static bool AreCollectionsEqual(IReadOnlyCollection<string>? a, IReadOnlyCollection<string>? b)
+    {
+        if (ReferenceEquals(a, b))
+            return true;
+        if (a is null || b is null)
+            return false;
+        bool bReturn = a.Count == b.Count && !a.Except(b).Any();
+        return bReturn;
+    }
+
+    /// <summary>
+    /// Override the GetHashCode for completeness for equality checking
+    /// </summary>
+    /// <returns>integer hash code for this ServiceTarget</returns>
+    public override int GetHashCode()
+    {
+        int hash = 17;
+        hash = hash * 23 + (EntityIds is null ? 0 : GetCollectionHashCode(EntityIds));
+        hash = hash * 23 + (DeviceIds is null ? 0 : GetCollectionHashCode(DeviceIds));
+        hash = hash * 23 + (AreaIds is null ? 0 : GetCollectionHashCode(AreaIds));
+        hash = hash * 23 + (FloorIds is null ? 0 : GetCollectionHashCode(FloorIds));
+        hash = hash * 23 + (LabelIds is null ? 0 : GetCollectionHashCode(LabelIds));
+        return hash;
+    }
+
+    private static int GetCollectionHashCode(IReadOnlyCollection<string> collection)
+    {
+        unchecked
+        {
+            int hash = 19;
+            foreach (var item in collection.OrderBy(x => x))
+            {
+                hash = hash * 31 + item.GetHashCode(StringComparison.Ordinal);
+            }
+            return hash;
+        }
+    }
+
+
+    /// <summary>
     /// Creates a new empty ServiceTarget
     /// </summary>
     public ServiceTarget()
@@ -59,4 +130,5 @@ public class ServiceTarget
     /// Ids of labels to invoke a service on
     /// </summary>
     public IReadOnlyCollection<string>? LabelIds { get; init; }
+
 }


### PR DESCRIPTION
Add Equal.object to ServiceTarget so equivalency can be used in Fluent Assertions.  Without this since ServiceTarget is a class the only check is if two objects are the SAME object (i.e. reference check only)